### PR TITLE
First implementation of influxdb collector plugin

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,37 @@
+# Compiled Object files, Static and Dynamic libs (Shared Objects)
+*.o
+*.a
+*.so
+
+# Folders
+_obj
+_test
+
+# Architecture specific extensions/prefixes
+*.[568vq]
+[568vq].out
+
+*.cgo1.go
+*.cgo2.c
+_cgo_defun.c
+_cgo_gotypes.go
+_cgo_export.*
+
+_testmain.go
+
+*.exe
+*.test
+.idea
+tmp/
+*.tmp
+scratch/
+build/
+*.swp
+profile.cov
+gin-bin
+
+# we don't vendor godep _workspace
+**/Godeps/_workspace/**
+
+# OSX stuff
+.DS_Store

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,24 @@
+sudo: required
+language: go
+go:
+- 1.4.3
+- 1.5.3
+env:
+  global:
+    - SNAP_PLUGIN_SOURCE=/home/travis/gopath/src/github.com/intelsdi-x/snap-plugin-collector-influxdb
+  matrix:
+    - TEST=unit
+before_install:
+- go get github.com/tools/godep
+- go get github.com/intelsdi-x/snap
+- if [ ! -d $SNAP_PLUGIN_SOURCE ]; then mkdir -p $HOME/gopath/src/github.com/intelsdi-x; ln -s $TRAVIS_BUILD_DIR $SNAP_PLUGIN_SOURCE; fi # CI for forks not from intelsdi-x
+install:
+- export TMPDIR=$HOME/tmp
+- mkdir -p $TMPDIR
+- cd $SNAP_PLUGIN_SOURCE # change dir into source
+- make deps
+script:
+- make check TEST=$TEST 2>&1 # Run test suite
+notifications:
+  slack:
+    secure: VkbZLIc2RH8yf3PtIAxUNPdAu3rQQ7yQx0GcK124JhbEnZGaHyK615V0rbG7HcVmYKGPdB0cXqZiLBDKGqGKb2zR1NepOe1nF03jxGSpPq8jIFeEXSJGEYGL34ScDzZZGuG6qwbjFcXiW5lqn6t8igzp7v2+URYBaZo5ktCS2xY=

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,47 @@
+# snap collector plugin - influxdb
+
+1. [Contributing Code](#contributing-code)
+2. [Contributing Examples](#contributing-examples)
+3. [Contribute Elsewhere](#contribute-elsewhere)
+4. [Thank You](#thank-you)
+
+
+This repository is primarily **community supported**. We both appreciate and need your contribution to keep it stable.
+Thank you for being part of the community! We love you for it.
+
+## Contributing Code
+**_IMPORTANT_**: We encourage contributions to the project from the community. We ask that you keep the following guidelines in mind when planning your contribution.
+
+* Whether your contribution is for a bug fix or a feature request, **create an [Issue](https://github.com/intelsdi-x/snap-plugin-collector-influxdb/issues)** and let us know what you are thinking
+* **For bugs**, if you have already found a fix, feel free to submit a Pull Request referencing the Issue you created
+* **For feature requests**, we want to improve upon the library incrementally which means small changes at a time. In order ensure your PR can be reviewed in a timely manner, please keep PRs small, e.g. <10 files and <500 lines changed. If you think this is unrealistic, then mention that within the issue and we can discuss it
+
+Once you're ready to contribute code back to this repo, start with these steps:
+
+* Fork the appropriate sub-projects that are affected by your change
+* Clone the fork to `$GOPATH/src/github.com/intelsdi-x/`  
+	```
+	$ git clone https://github.com/<yourGithubID>/<project>.git
+	```
+* Create a topic branch for your change and checkout that branch  
+    ```
+    $ git checkout -b some-topic-branch
+    ```
+* Make your changes and run the test suite if one is provided (see below)
+* Commit your changes and push them to your fork
+* Open a pull request for the appropriate project
+* Contributors will review your pull request, suggest changes, and merge it when it’s ready and/or offer feedback
+* To report a bug or issue, please open a new issue against this repository
+
+If you have questions feel free to contact the [maintainers](https://github.com/intelsdi-x/snap/blob/master/README.md#maintainers).
+
+## Contributing Examples
+The most immediately helpful way you can benefit this project is by cloning the repository, adding some further examples and submitting a pull request.
+
+Have you written a blog post about how you use [snap](http://github.com/intelsdi-x/snap) and/or this plugin? Send it to us!
+
+## Contribute Elsewhere
+This repository is one of **many** plugins in **snap**, a powerful telemetry framework. See the full project at http://github.com/intelsdi-x/snap
+
+## Thank You
+And **thank you!** Your contribution, through code and participation, is incredibly important to us.

--- a/Godeps/Godeps.json
+++ b/Godeps/Godeps.json
@@ -1,0 +1,10 @@
+{
+	"ImportPath": "github.com/intelsdi-x/snap-plugin-collector-influxdb",
+	"GoVersion": "go1.5",
+	"Deps": [
+		{
+			"ImportPath": "github.com/intelsdi-x/snap-plugin-utilities",
+			"Rev": "f6ebcc7cdefd9a74e256187e638ad6fa62487629"
+		}
+	]
+}

--- a/Godeps/Readme
+++ b/Godeps/Readme
@@ -1,0 +1,5 @@
+This directory tree is generated automatically by godep.
+
+Please do not edit.
+
+See https://github.com/tools/godep for more information.

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,202 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,11 @@
+default:
+	$(MAKE) deps
+	$(MAKE) all
+deps:
+	bash -c "godep restore"
+test:
+	bash -c "./scripts/test.sh $(TEST)"
+check:
+	$(MAKE) test
+all:
+	bash -c "./scripts/build.sh $(shell dirname $(realpath $(lastword $(MAKEFILE_LIST))))"

--- a/README.md
+++ b/README.md
@@ -1,2 +1,361 @@
-# snap-plugin-collector-influxdb
-InfluxDB Internal Statistics Collector Plugin
+# snap collector plugin - influxdb
+
+This plugin collects statistical and diagnostic information about each InfluxDB node. This information can be very useful to assist with troubleshooting and performance analysis of the database itself.
+
+This plugin gather InfluxDB internal system monitoring information in response to commands `SHOW STATS` and `SHOW DIAGNOSTICS`.
+															
+The plugin is used in the [snap framework] (http://github.com/intelsdi-x/snap).				
+
+1. [Getting Started](#getting-started)
+  * [System Requirements](#system-requirements)
+  * [Installation](#installation)
+  * [Configuration and Usage](#configuration-and-usage)
+2. [Documentation](#documentation)
+  * [Global Config](#global-config)
+  * [Collected Metrics](#collected-metrics)
+  * [Examples](#examples)
+  * [Roadmap](#roadmap)
+3. [Community Support](#community-support)
+4. [Contributing](#contributing)
+5. [License](#license)
+6. [Acknowledgements](#acknowledgements)
+
+## Getting Started
+
+### System Requirements
+
+- Linux system
+- InfluxDB (version 0.9 or higher)
+
+### Installation
+
+#### To build the plugin binary:
+
+Fork https://github.com/intelsdi-x/snap-plugin-collector-influxdb																				
+
+Clone repo into `$GOPATH/src/github.com/intelsdi-x/`:
+
+```
+$ git clone https://github.com/<yourGithubID>/snap-plugin-collector-influxdb.git
+```
+
+Build the snap influxdb collector plugin by running make within the cloned repo:
+```
+$ make
+```
+This builds the plugin in `/build/rootfs/`
+
+### Configuration and Usage
+
+* Set up the [snap framework](https://github.com/intelsdi-x/snap/blob/master/README.md#getting-started)
+
+
+## Documentation
+
+To learn more about influxDB System Monitoring, visit:
+
+* [InfluxDB Server Monitoring doc] (https://docs.influxdata.com/influxdb/v0.9/administration/statistics/)
+* [InfluxDB Server Monitoring README] (https://github.com/influxdata/influxdb/blob/master/monitor/README.md)
+* blog post ["How to use the show stats command to monitor InfluxDB"](https://influxdata.com/blog/how-to-use-the-show-stats-command-and-the-_internal-database-to-monitor-influxdb/)
+
+### Global Config
+
+Global configuration files are described in snap's documentation. For this plugin section "influxdb" in "collector" specifing the following options needs to be added (see [exemplary configs file](examples/configs/snap-config-sample.json)):
+
+Name 	  	| Data Type | Description
+------------|-----------|-----------------------
+"host" 		| string 	| hostname of InfluxDB http API
+"port" 		| int	 	| port of InfluxDB http API (by default 8086)
+"user" 		| string 	| user name
+"password" 	| string 	| user password
+
+
+### Collected Metrics
+
+This plugin has the ability to gather:
+
+a) all **diagnostic information** of InfluxDB system itself, represented by the metrics with prefix `/intel/influxdb/diagn/`
+
+b) all **statistical information** of InfluxDB system itself, represented by the metrics with prefix `/intel/influxdb/stat/`
+                                                                                                
+Metric Name | Description
+------------ | -------------
+/intel/influxdb/diagn/build/Branch |
+/intel/influxdb/diagn/build/Commit |
+/intel/influxdb/diagn/build/Version |
+/intel/influxdb/diagn/network/hostname |
+/intel/influxdb/diagn/runtime/GOARCH |
+/intel/influxdb/diagn/runtime/GOMAXPROCS |
+/intel/influxdb/diagn/runtime/GOOS |
+/intel/influxdb/diagn/runtime/version |
+/intel/influxdb/diagn/system/PID |
+/intel/influxdb/diagn/system/currentTime |
+/intel/influxdb/diagn/system/started |
+/intel/influxdb/diagn/system/uptime |
+| |
+/intel/influxdb/stat/engine/<engine_id>/blks_write |
+/intel/influxdb/stat/engine/<engine_id>/blks_write_bytes |
+/intel/influxdb/stat/engine/<engine_id>/blks_write_bytes_c |
+/intel/influxdb/stat/engine/<engine_id>/points_write |
+/intel/influxdb/stat/engine/<engine_id>/points_write_dedupe |
+/intel/influxdb/stat/httpd/auth_fail |
+/intel/influxdb/stat/httpd/ping_req |
+/intel/influxdb/stat/httpd/points_written_ok |
+/intel/influxdb/stat/httpd/query_req |
+/intel/influxdb/stat/httpd/query_resp_bytes |
+/intel/influxdb/stat/httpd/req |
+/intel/influxdb/stat/httpd/write_req |
+/intel/influxdb/stat/httpd/write_req_bytes |
+/intel/influxdb/stat/runtime/Alloc |
+/intel/influxdb/stat/runtime/Frees |
+/intel/influxdb/stat/runtime/HeapAlloc |
+/intel/influxdb/stat/runtime/HeapIdle |
+/intel/influxdb/stat/runtime/HeapInUse |
+/intel/influxdb/stat/runtime/HeapObjects |
+/intel/influxdb/stat/runtime/HeapReleased |
+/intel/influxdb/stat/runtime/HeapSys |
+/intel/influxdb/stat/runtime/Lookups |
+/intel/influxdb/stat/runtime/Mallocs |
+/intel/influxdb/stat/runtime/NumGC |
+/intel/influxdb/stat/runtime/NumGoroutine |
+/intel/influxdb/stat/runtime/PauseTotalNs |
+/intel/influxdb/stat/runtime/Sys |
+/intel/influxdb/stat/runtime/TotalAlloc |
+/intel/influxdb/stat/shard/<shard_id>/fields_create |
+/intel/influxdb/stat/shard/<shard_id>/series_create |
+/intel/influxdb/stat/shard/<shard_id>/write_points_ok |
+/intel/influxdb/stat/shard/<shard_id>/write_req |
+/intel/influxdb/stat/write/point_req |
+/intel/influxdb/stat/write/point_req_local |
+/intel/influxdb/stat/write/req |
+/intel/influxdb/stat/write/write_ok |
+
+The list of available metrics might be vary depending on the influxdb version or the system configuration.
+
+Diagnostics information are gathered only once at the beggining of collecting process, because they are constant during running the influxdb process.
+
+In task manifest there are declaration of metrics names which will be collected and an interval (see [exemplary task manifest] (examples/tasks/influxdb-file.json)). By default metrics are gathered once per second.
+
+There is a possibility to use asterisk (*) in metrics names (in all levels), for example:
+ - `/intel/influxdb/*` means that all available metrics representing statistical and diagnostic information will be collected
+ - `/intel/influxdb/stat/*` means that all metrics representing statistical information will be collected
+ - `/intel/influxdb/stat/httpd/*` means that only metrics for module `httpd` will be collected (i.e.: auth_fail, req, ping_req, query_req, query_resp_bytes, write_req, write_req_bytes, points_written_ok)
+
+
+### Examples
+
+Example of running snap influxdb collector and writing data to file.
+
+Run the snap daemon:
+```
+$ snapd -l 1 -t 0 --config $SNAP_INFLUXDB_COLLECTOR_PLUGIN_DIR/examples/configs/snap-config-sample.json
+```
+
+Load snap influxdb collector plugin:
+```
+$ snapctl plugin load $SNAP_INFLUXDB_COLLECTOR_PLUGIN_DIR/build/rootfs/snap-plugin-collector-influxdb
+Plugin loaded
+Name: influxdb
+Version: 1
+Type: collector
+Signed: false
+Loaded Time: Fri, 26 Feb 2016 09:09:03 UTC
+```
+See all available metrics:
+```
+$ snapctl metric list
+
+NAMESPACE                                                VERSIONS
+/intel/influxdb/*                                        1
+/intel/influxdb/diagn/*                                  1
+/intel/influxdb/diagn/build/*                            1
+/intel/influxdb/diagn/build/Branch                       1
+/intel/influxdb/diagn/build/Commit                       1
+/intel/influxdb/diagn/build/Version                      1
+/intel/influxdb/diagn/network/*                          1
+/intel/influxdb/diagn/network/hostname                   1
+/intel/influxdb/diagn/runtime/*                          1
+/intel/influxdb/diagn/runtime/GOARCH                     1
+/intel/influxdb/diagn/runtime/GOMAXPROCS                 1
+/intel/influxdb/diagn/runtime/GOOS                       1
+/intel/influxdb/diagn/runtime/version                    1
+/intel/influxdb/diagn/system/*                           1
+/intel/influxdb/diagn/system/PID                         1
+/intel/influxdb/diagn/system/currentTime                 1
+/intel/influxdb/diagn/system/started                     1
+/intel/influxdb/diagn/system/uptime                      1
+/intel/influxdb/stat/*                                   1
+/intel/influxdb/stat/engine/*                            1
+/intel/influxdb/stat/engine/1/*                          1
+/intel/influxdb/stat/engine/1/blks_write                 1
+/intel/influxdb/stat/engine/1/blks_write_bytes           1
+/intel/influxdb/stat/engine/1/blks_write_bytes_c         1
+/intel/influxdb/stat/engine/1/points_write               1
+/intel/influxdb/stat/engine/1/points_write_dedupe        1
+/intel/influxdb/stat/engine/2/*                          1
+/intel/influxdb/stat/engine/2/blks_write                 1
+/intel/influxdb/stat/engine/2/blks_write_bytes           1
+/intel/influxdb/stat/engine/2/blks_write_bytes_c         1
+/intel/influxdb/stat/engine/2/points_write               1
+/intel/influxdb/stat/engine/2/points_write_dedupe        1
+/intel/influxdb/stat/httpd/*                             1
+/intel/influxdb/stat/httpd/auth_fail                     1
+/intel/influxdb/stat/httpd/ping_req                      1
+/intel/influxdb/stat/httpd/points_written_ok             1
+/intel/influxdb/stat/httpd/query_req                     1
+/intel/influxdb/stat/httpd/query_resp_bytes              1
+/intel/influxdb/stat/httpd/req                           1
+/intel/influxdb/stat/httpd/write_req                     1
+/intel/influxdb/stat/httpd/write_req_bytes               1
+/intel/influxdb/stat/runtime/*                           1
+/intel/influxdb/stat/runtime/Alloc                       1
+/intel/influxdb/stat/runtime/Frees                       1
+/intel/influxdb/stat/runtime/HeapAlloc                   1
+/intel/influxdb/stat/runtime/HeapIdle                    1
+/intel/influxdb/stat/runtime/HeapInUse                   1
+/intel/influxdb/stat/runtime/HeapObjects                 1
+/intel/influxdb/stat/runtime/HeapReleased                1
+/intel/influxdb/stat/runtime/HeapSys                     1
+/intel/influxdb/stat/runtime/Lookups                     1
+/intel/influxdb/stat/runtime/Mallocs                     1
+/intel/influxdb/stat/runtime/NumGC                       1
+/intel/influxdb/stat/runtime/NumGoroutine                1
+/intel/influxdb/stat/runtime/PauseTotalNs                1
+/intel/influxdb/stat/runtime/Sys                         1
+/intel/influxdb/stat/runtime/TotalAlloc                  1
+/intel/influxdb/stat/shard/*                             1
+/intel/influxdb/stat/shard/1/*                           1
+/intel/influxdb/stat/shard/1/fields_create               1
+/intel/influxdb/stat/shard/1/series_create               1
+/intel/influxdb/stat/shard/1/write_points_ok             1
+/intel/influxdb/stat/shard/1/write_req                   1
+/intel/influxdb/stat/shard/2/*                           1
+/intel/influxdb/stat/shard/2/fields_create               1
+/intel/influxdb/stat/shard/2/series_create               1
+/intel/influxdb/stat/shard/2/write_points_ok             1
+/intel/influxdb/stat/shard/2/write_req                   1
+/intel/influxdb/stat/write/*                             1
+/intel/influxdb/stat/write/point_req                     1
+/intel/influxdb/stat/write/point_req_local               1
+/intel/influxdb/stat/write/req                           1
+/intel/influxdb/stat/write/write_ok                      1
+
+```
+
+Load file plugin for publishing:
+```
+$ snapctl plugin load $SNAP_DIR/build/plugin/snap-publisher-file
+Plugin loaded
+Name: file
+Version: 3
+Type: publisher
+Signed: false
+Loaded Time: Fri, 26 Feb 2016 09:16:44 UTC
+```
+
+Create a task JSON file (exemplary file in examples/tasks/influxdb-file.json):  
+```json
+
+{
+    "version": 1,
+    "schedule": {
+        "type": "simple",
+        "interval": "1s"
+    },
+    "workflow": {
+        "collect": {
+            "metrics": {
+                "/intel/influxdb/stat/httpd/*": {},
+				"/intel/influxdb/stat/write/*": {},
+				"/intel/influxdb/stat/runtime/Alloc": {},
+				"/intel/influxdb/stat/runtime/Frees": {},
+				"/intel/influxdb/diagn/system/PID" : {}
+            },
+            "config": {},
+            "process": null,
+            "publish": [
+                {
+                    "plugin_name": "file",
+                    "config": {
+                        "file": "/tmp/published_influxdb_internal_monitoring"
+                    }
+                }
+            ]
+        }
+    }
+}
+```
+
+Create a task:
+```
+$ snapctl task create -t $SNAP_INFLUXDB_COLLECTOR_PLUGIN_DIR/examples/tasks/influxdb-file.json
+Using task manifest to create task
+Task created
+ID: d4392f17-11f0-4f64-8701-2708f432b50a
+Name: Task-d4392f17-11f0-4f64-8701-2708f432b50a
+State: Running
+```
+
+See sample output from `snapctl task watch <task_id>`
+
+```
+$ snapctl task watch d4392f17-11f0-4f64-8701-2708f432b50a
+
+Watching Task (d4392f17-11f0-4f64-8701-2708f432b50a):
+NAMESPACE                                        DATA                    TIMESTAMP                                       SOURCE
+/intel/influxdb/diagn/system/PID                 16191                   2016-02-26 09:25:47.353886681 +0000 UTC         node-25.domain.tld
+/intel/influxdb/stat/httpd/auth_fail             63                      2016-02-26 09:25:47.354068464 +0000 UTC         node-25.domain.tld
+/intel/influxdb/stat/httpd/ping_req              14                      2016-02-26 09:25:47.354073486 +0000 UTC         node-25.domain.tld
+/intel/influxdb/stat/httpd/points_written_ok     6.69802551e+08          2016-02-26 09:25:47.354137322 +0000 UTC         node-25.domain.tld
+/intel/influxdb/stat/httpd/query_req             2310                    2016-02-26 09:25:47.354132981 +0000 UTC         node-25.domain.tld
+/intel/influxdb/stat/httpd/query_resp_bytes      2.0678075e+07           2016-02-26 09:25:47.354113672 +0000 UTC         node-25.domain.tld
+/intel/influxdb/stat/httpd/req                   6.824003e+06            2016-02-26 09:25:47.354028193 +0000 UTC         node-25.domain.tld
+/intel/influxdb/stat/httpd/write_req             6.821614e+06            2016-02-26 09:25:47.354095848 +0000 UTC         node-25.domain.tld
+/intel/influxdb/stat/httpd/write_req_bytes       7.1455502846e+10        2016-02-26 09:25:47.354105454 +0000 UTC         node-25.domain.tld
+/intel/influxdb/stat/runtime/Alloc               1.07946848e+08          2016-02-26 09:25:47.354209458 +0000 UTC         node-25.domain.tld
+/intel/influxdb/stat/runtime/Frees               1.5858776371e+10        2016-02-26 09:25:47.354412092 +0000 UTC         node-25.domain.tld
+/intel/influxdb/stat/write/point_req             6.82720753e+08          2016-02-26 09:25:47.354579209 +0000 UTC         node-25.domain.tld
+/intel/influxdb/stat/write/point_req_local       6.82720753e+08          2016-02-26 09:25:47.354619612 +0000 UTC         node-25.domain.tld
+/intel/influxdb/stat/write/req                   7.000631e+06            2016-02-26 09:25:47.354624219 +0000 UTC         node-25.domain.tld
+/intel/influxdb/stat/write/write_ok              7.000823e+06            2016-02-26 09:25:47.354609029 +0000 UTC         node-25.domain.tld
+
+```
+(Keys `ctrl+c` terminate task watcher)
+
+
+These data are published to file and stored there (in this example in /tmp/published_influxdb_internal_monitoring).
+
+Stop task:
+```
+$ snapctl task stop d4392f17-11f0-4f64-8701-2708f432b50a
+Task stopped:
+ID: d4392f17-11f0-4f64-8701-2708f432b50a
+```
+
+### Roadmap
+
+There isn't a current roadmap for this plugin, but it is in active development. As we launch this plugin, we do not have any outstanding requirements for the next release.
+
+If you have a feature request, please add it as an [issue](https://github.com/intelsdi-x/snap-plugin-collector-influxdb/issues).
+
+## Community Support
+This repository is one of **many** plugins in the **Snap Framework**: a powerful telemetry agent framework. To reach out on other use cases, visit:
+
+* [Snap Gitter channel] (https://gitter.im/intelsdi-x/snap)
+
+The full project is at http://github.com:intelsdi-x/snap.
+
+## Contributing
+We love contributions!
+
+There's more than one way to give back, from examples to blogs to code updates. See our recommended process in [CONTRIBUTING.md](CONTRIBUTING.md).
+
+## License
+Snap, along with this plugin, is an Open Source software released under the Apache 2.0 [License](LICENSE).
+
+## Acknowledgements
+List authors, co-authors and anyone you'd like to mention
+
+* Author: 	[Izabella Raulin](https://github.com/IzabellaRaulin)
+
+**Thank you!** Your contribution is incredibly important to us.

--- a/examples/configs/snap-config-sample.json
+++ b/examples/configs/snap-config-sample.json
@@ -1,0 +1,23 @@
+{
+    "control": {
+        "cache_ttl": "5s"
+    },
+    "scheduler": {
+        "default_deadline": "5s",
+        "worker_pool_size": 5
+    },
+    "plugins": {
+        "collector": {
+            "influxdb": {
+                "all": {
+                    "host": "localhost",
+                    "port": 8086,
+                    "user": "root",
+                    "password": "influx"
+                }
+            }
+        },
+        "publisher": {},
+        "processor": {}
+    }
+}

--- a/examples/tasks/influxdb-file.json
+++ b/examples/tasks/influxdb-file.json
@@ -1,0 +1,24 @@
+{
+    "version": 1,
+    "schedule": {
+        "type": "simple",
+        "interval": "1s"
+    },
+    "workflow": {
+        "collect": {
+            "metrics": {
+                "/intel/influxdb/stat/*": {}
+            },
+            "config": {},
+            "process": null,
+            "publish": [
+                {
+                    "plugin_name": "file",
+                    "config": {
+                        "file": "/tmp/published_influxdb_internal_monitoring"
+                    }
+                }
+            ]
+        }
+    }
+}

--- a/influxdb/dtype/dtype.go
+++ b/influxdb/dtype/dtype.go
@@ -1,0 +1,26 @@
+// +build linux
+
+/*
+http://www.apache.org/licenses/LICENSE-2.0.txt
+Copyright 2016 Intel Corporation
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package dtype
+
+// Results represents InfluxDB Monitoring results
+type Results map[string]*Series
+
+// Series represents InfluxDB Monitoring series
+type Series struct {
+	Data map[string]interface{}
+	Tags map[string]string
+}

--- a/influxdb/influxdb.go
+++ b/influxdb/influxdb.go
@@ -1,0 +1,252 @@
+// +build linux
+
+/*
+http://www.apache.org/licenses/LICENSE-2.0.txt
+Copyright 2016 Intel Corporation
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package influxdb
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"regexp"
+	"strings"
+	"time"
+
+	"github.com/intelsdi-x/snap/control/plugin"
+	"github.com/intelsdi-x/snap/control/plugin/cpolicy"
+
+	"github.com/intelsdi-x/snap-plugin-collector-influxdb/influxdb/dtype"
+	"github.com/intelsdi-x/snap-plugin-collector-influxdb/influxdb/monitor"
+	"github.com/intelsdi-x/snap-plugin-utilities/config"
+)
+
+const (
+	// Name of plugin
+	Name = "influxdb"
+	// Version of plugin
+	Version = 1
+	// Type of plugin
+	Type = plugin.CollectorPluginType
+
+	nsVendor = "intel"
+	nsClass  = "influxdb"
+
+	nsTypeStats = "stat"
+	nsTypeDiagn = "diagn"
+)
+
+const (
+	typeUnknown = iota
+	typeStats
+	typeDiagn
+)
+
+// prefix in metric namespace
+var prefix = []string{nsVendor, nsClass}
+
+// InfluxdbCollector holds data retrived from influxDB system monitoring
+type InfluxdbCollector struct {
+	data        map[string]datum
+	service     monitor.Monitoring
+	initialized bool
+}
+
+type datum struct {
+	value interface{}
+	tags  map[string]string
+}
+
+// New returns new instance of snap-plugin-collector-influxdb
+func New() *InfluxdbCollector {
+	return &InfluxdbCollector{initialized: false, service: &monitor.Monitor{}, data: map[string]datum{}}
+}
+
+// GetConfigPolicy returns a ConfigPolicy
+func (ic *InfluxdbCollector) GetConfigPolicy() (*cpolicy.ConfigPolicy, error) {
+	return cpolicy.New(), nil
+}
+
+// GetMetricTypes returns list of metrics based on influxDB system monitoring
+func (ic *InfluxdbCollector) GetMetricTypes(cfg plugin.PluginConfigType) ([]plugin.PluginMetricType, error) {
+	mts := []plugin.PluginMetricType{}
+
+	ic.init(cfg)
+	ic.getStatistics()  // get statistical information about influxDB
+	ic.getDiagnostics() // get diagnostic information about influxDB
+
+	for ns, dat := range ic.data {
+		mts = append(mts, plugin.PluginMetricType{Namespace_: splitNamespace(ns), Tags_: dat.tags})
+	}
+
+	// whildcards support
+	mts = append(mts, getWildCardMetrics(mts)...)
+	return mts, nil
+}
+
+// CollectMetrics collects given metrics
+func (ic *InfluxdbCollector) CollectMetrics(mts []plugin.PluginMetricType) ([]plugin.PluginMetricType, error) {
+	metrics := []plugin.PluginMetricType{}
+	hostname, _ := os.Hostname()
+
+	if !ic.initialized {
+		ic.init(mts[0])     // if CollectMetrics() is called, mts has one item at least
+		ic.getDiagnostics() // get diagnostic information (once only)
+	}
+
+	ic.getStatistics() // get statistical information
+
+	for _, m := range mts {
+
+		// prepare namespace to regular expression (wildcards support)
+		name := joinNamespace(m.Namespace())
+		name = strings.Replace(name, "/", "\\/", -1)
+		name = strings.Replace(name, "*", ".*", -1)
+		regex := regexp.MustCompile("^" + name + "$")
+
+		for key := range ic.data {
+			match := regex.FindStringSubmatch(key)
+
+			if match == nil {
+				continue
+			}
+
+			if dat, ok := ic.data[key]; ok {
+				metric := plugin.PluginMetricType{
+					Namespace_: splitNamespace(key),
+					Data_:      dat.value,
+					Source_:    hostname,
+					Timestamp_: time.Now(),
+					Tags_:      dat.tags,
+				}
+
+				metrics = append(metrics, metric)
+			}
+		}
+	}
+
+	return metrics, nil
+}
+
+// init initializes InfluxdbCollector instance based on config `cfg`
+func (ic *InfluxdbCollector) init(cfg interface{}) {
+	items := []string{"host", "port", "user", "password"}
+	settings, err := config.GetConfigItems(cfg, items)
+	handleErr(err)
+
+	err = ic.service.InitURLs(settings)
+	handleErr(err)
+
+	ic.initialized = true
+}
+
+// getDiagnostics executes the command "SHOW DIAGNOSTICS" (indirectly)
+func (ic *InfluxdbCollector) getDiagnostics() {
+	err := ic.getData(typeDiagn)
+	if err != nil {
+		fmt.Fprintln(os.Stderr, "Cannot get influxdb diagnostic information, err=", err)
+	}
+}
+
+// getStatistics executes the command "SHOW STATS" (indirectly)
+func (ic *InfluxdbCollector) getStatistics() {
+
+	err := ic.getData(typeStats)
+	if err != nil {
+		fmt.Fprintln(os.Stderr, "Cannot get influxdb internal statistics, err=", err)
+	}
+}
+
+// getData executes a command specified by given `type` of desired data
+// and assignes its results to InfluxdbCollector structure item `data`
+func (ic *InfluxdbCollector) getData(kind int) error {
+	var results dtype.Results
+	var err error
+	var nsType string
+
+	switch kind {
+	case typeStats:
+		nsType = nsTypeStats
+		results, err = ic.service.GetStatistics()
+
+	case typeDiagn:
+		nsType = nsTypeDiagn
+		results, err = ic.service.GetDiagnostics()
+
+	default:
+		err = errors.New("Inalid type of monitoring service")
+	}
+
+	if err != nil {
+		return err
+	}
+
+	for seriesName, series := range results {
+		for columnName := range series.Data {
+			key := createNamespace(nsType, seriesName, columnName)
+			ic.data[key] = datum{
+				value: series.Data[columnName],
+				tags:  series.Tags,
+			}
+
+		}
+	}
+
+	return nil
+}
+
+// getWildCardMetrics extends list of metrics `mts` about wildcard metrics on each level; only asterisk (*) is supported for now
+func getWildCardMetrics(mts []plugin.PluginMetricType) []plugin.PluginMetricType {
+	extendedMts := []plugin.PluginMetricType{}
+	prefixLen := len(prefix)
+
+	for _, m := range mts {
+		mNameLen := len(m.Namespace())
+		for index := range m.Namespace()[prefixLen:mNameLen] {
+			ns := make([]string, mNameLen)
+			copy(ns, m.Namespace())
+
+			metric := append(ns[:prefixLen+index], "*")
+			extendedMts = append(extendedMts, plugin.PluginMetricType{Namespace_: metric, Tags_: m.Tags()})
+		}
+	}
+
+	return extendedMts
+}
+
+// handleErr handles critical error indicated with an abnormal state of plugin
+func handleErr(err error) {
+	if err != nil {
+		panic(err)
+	}
+}
+
+// createNamespace returns namespace composed from prefix, type of metric and metric name's components (the elements are joined to a single string)
+func createNamespace(nsType, seriesName, columnName string) string {
+	ns := append(prefix, nsType)
+	ns = append(ns, seriesName)
+	ns = append(ns, columnName)
+	return strings.Join(ns, "/")
+
+}
+
+// joinNamespace concatenates the elements of `ns` to create a single string combined by slash
+func joinNamespace(ns []string) string {
+	return strings.Join(ns, "/")
+}
+
+//splitNamespace splits namespace (repesented by single string `s`) and returns  a slice of the substrings beetween slash separator
+func splitNamespace(ns string) []string {
+	return strings.Split(ns, "/")
+}

--- a/influxdb/influxdb_test.go
+++ b/influxdb/influxdb_test.go
@@ -1,0 +1,399 @@
+// +build linux
+
+/*
+http://www.apache.org/licenses/LICENSE-2.0.txt
+Copyright 2016 Intel Corporation
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package influxdb
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/intelsdi-x/snap-plugin-collector-influxdb/influxdb/dtype"
+
+	"github.com/intelsdi-x/snap/control/plugin"
+	"github.com/intelsdi-x/snap/core/cdata"
+	"github.com/intelsdi-x/snap/core/ctypes"
+
+	. "github.com/smartystreets/goconvey/convey"
+	"github.com/stretchr/testify/mock"
+)
+
+type mcMock struct {
+	mock.Mock
+}
+
+func (mc *mcMock) GetStatistics() (dtype.Results, error) {
+	args := mc.Called()
+	return args.Get(0).(dtype.Results), args.Error(1)
+}
+
+func (mc *mcMock) GetDiagnostics() (dtype.Results, error) {
+	args := mc.Called()
+	return args.Get(0).(dtype.Results), args.Error(1)
+}
+
+func (mc *mcMock) InitURLs(settings map[string]interface{}) error {
+	args := mc.Called()
+	return args.Error(0)
+}
+
+var mockStats = dtype.Results{
+
+	"shard/1": &dtype.Series{
+		Data: map[string]interface{}{
+			"columnA": 1,
+			"columnB": 10.1,
+			"columnC": "value",
+		},
+		Tags: map[string]string{
+			"tag1": "v1",
+			"tag2": "v2",
+		},
+	},
+	"httpd": &dtype.Series{
+		Data: map[string]interface{}{
+			"columnA": 1,
+			"columnB": 10.1,
+			"columnC": "value",
+		},
+		Tags: map[string]string{
+			"tag1": "v1",
+			"tag2": "v2",
+		},
+	},
+}
+
+var mockDiagn = dtype.Results{
+	"build": &dtype.Series{
+		Data: map[string]interface{}{
+			"columnA": 1,
+			"columnB": 10.1,
+			"columnC": "value",
+		},
+	},
+}
+
+var mockMtsStat = []plugin.PluginMetricType{
+	plugin.PluginMetricType{Namespace_: []string{"intel", "influxdb", "stat", "shard", "1", "columnA"}},
+	plugin.PluginMetricType{Namespace_: []string{"intel", "influxdb", "stat", "shard", "1", "columnB"}},
+	plugin.PluginMetricType{Namespace_: []string{"intel", "influxdb", "stat", "shard", "1", "columnC"}},
+	plugin.PluginMetricType{Namespace_: []string{"intel", "influxdb", "stat", "httpd", "columnA"}},
+	plugin.PluginMetricType{Namespace_: []string{"intel", "influxdb", "stat", "httpd", "columnB"}},
+	plugin.PluginMetricType{Namespace_: []string{"intel", "influxdb", "stat", "httpd", "columnC"}},
+}
+
+var mockMtsDiagn = []plugin.PluginMetricType{
+	plugin.PluginMetricType{Namespace_: []string{"intel", "influxdb", "diagn", "build", "columnA"}},
+	plugin.PluginMetricType{Namespace_: []string{"intel", "influxdb", "diagn", "build", "columnB"}},
+	plugin.PluginMetricType{Namespace_: []string{"intel", "influxdb", "diagn", "build", "columnC"}},
+}
+
+var mockMtsWildCards = []plugin.PluginMetricType{
+	plugin.PluginMetricType{Namespace_: []string{"intel", "influxdb", "diagn", "*"}},
+	plugin.PluginMetricType{Namespace_: []string{"intel", "influxdb", "stat", "*"}},
+}
+
+// Mts is a mocked metrics, both statistical and diagnostic
+var mockMts = append(mockMtsStat, mockMtsDiagn...)
+
+func TestGetConfigPolicy(t *testing.T) {
+	influxdbPlugin := New()
+
+	Convey("getting config policy", t, func() {
+		So(func() { influxdbPlugin.GetConfigPolicy() }, ShouldNotPanic)
+		_, err := influxdbPlugin.GetConfigPolicy()
+		So(err, ShouldBeNil)
+	})
+}
+
+func TestGetMetricTypes(t *testing.T) {
+
+	Convey("initialization fails", t, func() {
+
+		Convey("when no config items available", func() {
+			influxdbPlugin := New()
+			cfg := plugin.NewPluginConfigType()
+
+			So(func() { influxdbPlugin.GetMetricTypes(cfg) }, ShouldPanic)
+		})
+
+		Convey("when one of config item is not available", func() {
+			influxdbPlugin := New()
+			cfg := plugin.NewPluginConfigType()
+			cfg.DeleteItem("user")
+
+			So(func() { influxdbPlugin.GetMetricTypes(cfg) }, ShouldPanic)
+		})
+
+		Convey("when config item has different type than expected", func() {
+			influxdbPlugin := New()
+			cfg := plugin.NewPluginConfigType()
+			cfg.DeleteItem("port")
+			cfg.AddItem("port", ctypes.ConfigValueStr{Value: "1234"})
+
+			So(func() { influxdbPlugin.GetMetricTypes(cfg) }, ShouldPanic)
+		})
+
+		Convey("when initialization of URLs returns error", func() {
+			mc := &mcMock{}
+			influxdbPlugin := New()
+			influxdbPlugin.service = mc
+			cfg := plugin.NewPluginConfigType()
+
+			mc.On("InitURLs").Return(errors.New("x"))
+
+			So(func() { influxdbPlugin.GetMetricTypes(cfg) }, ShouldPanic)
+		})
+
+	})
+
+	Convey("Metrics are not available", t, func() {
+
+		Convey("when cannot obtain any data", func() {
+			mc := &mcMock{}
+			influxdbPlugin := New()
+			influxdbPlugin.service = mc
+			cfg := getMockPluginConfig()
+
+			mc.On("InitURLs").Return(nil)
+			mc.On("GetStatistics").Return(dtype.Results{}, errors.New("x"))
+			mc.On("GetDiagnostics").Return(dtype.Results{}, errors.New("x"))
+
+			So(func() { influxdbPlugin.GetMetricTypes(cfg) }, ShouldNotPanic)
+			results, err := influxdbPlugin.GetMetricTypes(cfg)
+
+			So(results, ShouldBeEmpty)
+			So(err, ShouldBeNil)
+		})
+
+		Convey("when cannot obtain statictics data", func() {
+			mc := &mcMock{}
+			influxdbPlugin := New()
+			influxdbPlugin.service = mc
+			cfg := getMockPluginConfig()
+
+			mc.On("InitURLs").Return(nil)
+			mc.On("GetStatistics").Return(dtype.Results{}, errors.New("x"))
+			mc.On("GetDiagnostics").Return(mockDiagn, nil)
+
+			So(func() { influxdbPlugin.GetMetricTypes(cfg) }, ShouldNotPanic)
+			results, err := influxdbPlugin.GetMetricTypes(cfg)
+
+			So(results, ShouldNotBeEmpty)
+			So(err, ShouldBeNil)
+		})
+
+		Convey("when cannot obtain diagnostics data", func() {
+			mc := &mcMock{}
+			influxdbPlugin := New()
+			influxdbPlugin.service = mc
+			cfg := getMockPluginConfig()
+
+			mc.On("InitURLs").Return(nil)
+			mc.On("GetStatistics").Return(mockStats, nil)
+			mc.On("GetDiagnostics").Return(dtype.Results{}, errors.New("x"))
+
+			So(func() { influxdbPlugin.GetMetricTypes(cfg) }, ShouldNotPanic)
+
+			So(func() { influxdbPlugin.GetMetricTypes(cfg) }, ShouldNotPanic)
+			results, err := influxdbPlugin.GetMetricTypes(cfg)
+
+			So(results, ShouldNotBeEmpty)
+			So(err, ShouldBeNil)
+		})
+	})
+
+	Convey("successfull getting metrics types", t, func() {
+		mc := &mcMock{}
+		influxdbPlugin := New()
+		influxdbPlugin.service = mc
+		cfg := getMockPluginConfig()
+
+		mc.On("InitURLs").Return(nil)
+		mc.On("GetStatistics").Return(mockStats, nil)
+		mc.On("GetDiagnostics").Return(mockDiagn, nil)
+
+		So(func() { influxdbPlugin.GetMetricTypes(cfg) }, ShouldNotPanic)
+
+		So(func() { influxdbPlugin.GetMetricTypes(cfg) }, ShouldNotPanic)
+		results, err := influxdbPlugin.GetMetricTypes(cfg)
+
+		So(results, ShouldNotBeEmpty)
+		So(err, ShouldBeNil)
+	})
+
+}
+
+func TestCollectMetrics(t *testing.T) {
+
+	mts := getMockMetricsConfigured()
+
+	Convey("initialization fails", t, func() {
+		mc := &mcMock{}
+		influxdbPlugin := New()
+		influxdbPlugin.service = mc
+
+		mc.On("InitURLs").Return(errors.New("x"))
+
+		So(func() { influxdbPlugin.CollectMetrics(mts) }, ShouldPanic)
+	})
+
+	Convey("metrics are not available", t, func() {
+		mc := &mcMock{}
+		influxdbPlugin := New()
+		influxdbPlugin.service = mc
+
+		mc.On("InitURLs").Return(nil)
+
+		Convey("when statistics data are not available", func() {
+			mc.On("GetStatistics").Return(dtype.Results{}, errors.New("x"))
+			mc.On("GetDiagnostics").Return(mockDiagn, nil)
+
+			So(func() { influxdbPlugin.CollectMetrics(mts) }, ShouldNotPanic)
+
+			results, err := influxdbPlugin.CollectMetrics(mts)
+
+			So(len(results), ShouldEqual, len(mockMtsDiagn))
+			So(err, ShouldBeNil)
+		})
+
+		Convey("when diagnostics data are not available", func() {
+			mc.On("GetStatistics").Return(mockStats, nil)
+			mc.On("GetDiagnostics").Return(dtype.Results{}, nil)
+
+			So(func() { influxdbPlugin.CollectMetrics(mts) }, ShouldNotPanic)
+
+			results, err := influxdbPlugin.CollectMetrics(mts)
+
+			So(len(results), ShouldEqual, len(mockMtsStat))
+			So(err, ShouldBeNil)
+		})
+
+	})
+
+	Convey("invalid metrics namespaces", t, func() {
+		mc := &mcMock{}
+		influxdbPlugin := New()
+		influxdbPlugin.service = mc
+		cfg := getMockMetricConfig()
+
+		mc.On("InitURLs").Return(nil)
+		mc.On("GetStatistics").Return(mockStats, nil)
+		mc.On("GetDiagnostics").Return(mockDiagn, nil)
+
+		Convey("when series type is unknown", func() {
+			mtsInvalid := []plugin.PluginMetricType{
+				plugin.PluginMetricType{Namespace_: []string{"intel", "influxdb", "unknown", "shard", "1", "columnA"},
+					Config_: cfg,
+				},
+			}
+
+			So(func() { influxdbPlugin.CollectMetrics(mtsInvalid) }, ShouldNotPanic)
+
+			results, err := influxdbPlugin.CollectMetrics(mtsInvalid)
+
+			So(results, ShouldBeEmpty)
+			So(err, ShouldBeNil)
+		})
+
+		Convey("when series name is empty", func() {
+			mtsInvalid := []plugin.PluginMetricType{
+				plugin.PluginMetricType{Namespace_: []string{"intel", "influxdb", "stats", ""},
+					Config_: cfg,
+				},
+			}
+			So(func() { influxdbPlugin.CollectMetrics(mtsInvalid) }, ShouldNotPanic)
+
+			results, err := influxdbPlugin.CollectMetrics(mtsInvalid)
+
+			So(results, ShouldBeEmpty)
+			So(err, ShouldBeNil)
+		})
+
+	})
+
+	Convey("successfull collect metrics", t, func() {
+
+		mc := &mcMock{}
+		influxdbPlugin := New()
+		influxdbPlugin.service = mc
+
+		mc.On("InitURLs").Return(nil)
+		mc.On("GetStatistics").Return(mockStats, nil)
+		mc.On("GetDiagnostics").Return(mockDiagn, nil)
+
+		Convey("when metrics namespaces are deliver directly", func() {
+
+			So(func() { influxdbPlugin.CollectMetrics(mts) }, ShouldNotPanic)
+
+			results, err := influxdbPlugin.CollectMetrics(mts)
+
+			So(results, ShouldNotBeEmpty)
+			So(err, ShouldBeNil)
+		})
+
+		Convey("when metrics namespaces contains wildcards", func() {
+
+			mtsWildCards := mockMtsWildCards
+			cfg := getMockMetricConfig()
+
+			// add mocked config to each metric
+			for i := range mtsWildCards {
+				mtsWildCards[i].Config_ = cfg
+			}
+			So(func() { influxdbPlugin.CollectMetrics(mtsWildCards) }, ShouldNotPanic)
+
+			results, err := influxdbPlugin.CollectMetrics(mtsWildCards)
+
+			So(len(results), ShouldEqual, len(mockMts))
+			So(err, ShouldBeNil)
+		})
+	})
+
+}
+
+func getMockPluginConfig() plugin.PluginConfigType {
+	// mocking global config
+	cfg := plugin.NewPluginConfigType()
+	cfg.AddItem("host", ctypes.ConfigValueStr{Value: "hostname"})
+	cfg.AddItem("port", ctypes.ConfigValueInt{Value: 1234})
+	cfg.AddItem("user", ctypes.ConfigValueStr{Value: "test"})
+	cfg.AddItem("password", ctypes.ConfigValueStr{Value: "passwd"})
+
+	return cfg
+}
+
+func getMockMetricConfig() *cdata.ConfigDataNode {
+	// mocking metric config
+	cfg := cdata.NewNode()
+	cfg.AddItem("host", ctypes.ConfigValueStr{Value: "hostname"})
+	cfg.AddItem("port", ctypes.ConfigValueInt{Value: 1234})
+	cfg.AddItem("user", ctypes.ConfigValueStr{Value: "test"})
+	cfg.AddItem("password", ctypes.ConfigValueStr{Value: "passwd"})
+
+	return cfg
+}
+
+func getMockMetricsConfigured() []plugin.PluginMetricType {
+	mts := mockMts
+	cfg := getMockMetricConfig()
+
+	// add mocked config to each metric
+	for i := range mts {
+		mts[i].Config_ = cfg
+	}
+
+	return mts
+}

--- a/influxdb/monitor/monitor.go
+++ b/influxdb/monitor/monitor.go
@@ -1,0 +1,119 @@
+// +build linux
+
+/*
+http://www.apache.org/licenses/LICENSE-2.0.txt
+Copyright 2016 Intel Corporation
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package monitor
+
+import (
+	"errors"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"net/url"
+	"os"
+
+	"github.com/intelsdi-x/snap-plugin-collector-influxdb/influxdb/dtype"
+	"github.com/intelsdi-x/snap-plugin-collector-influxdb/influxdb/parser"
+)
+
+// Monitoring is an interface represents data monitoring service
+// (needed for mocking purposes)
+type Monitoring interface {
+	GetStatistics() (dtype.Results, error)
+	GetDiagnostics() (dtype.Results, error)
+	InitURLs(sets map[string]interface{}) error
+}
+
+// Monitor holds urls
+type Monitor struct {
+	urlStatistic  *url.URL
+	urlDiagnostic *url.URL
+}
+
+// GetStatistics returns statistics information (url contains query "SHOW STATS")
+func (m *Monitor) GetStatistics() (dtype.Results, error) {
+	return getURLResults(m.urlStatistic.String())
+}
+
+// GetDiagnostics returns diagnostics information (url contains query "SHOW DIAGNOSTICS")
+func (m *Monitor) GetDiagnostics() (dtype.Results, error) {
+	return getURLResults(m.urlDiagnostic.String())
+}
+
+// InitURLs initializes URLs based on settings
+func (m *Monitor) InitURLs(settings map[string]interface{}) error {
+	var err1, err2 error
+
+	m.urlStatistic, err1 = createURL(settings, "show stats")
+	if err1 != nil {
+		fmt.Fprintln(os.Stderr, "Cannot parse raw url into a URL structure with `show stats` query, err=", err1)
+	}
+
+	m.urlDiagnostic, err2 = createURL(settings, "show diagnostics")
+	if err2 != nil {
+		fmt.Fprintln(os.Stderr, "Cannot parse raw url into a URL structure with `show diagnostics` query, err=", err2)
+	}
+
+	if err1 != nil && err2 != nil {
+		return errors.New("Invalid URL-encoding")
+	}
+
+	return nil
+}
+
+// createURL returns URL structure created base on `sets` (keeps info about hostname, port, etc.) and query state
+func createURL(sets map[string]interface{}, query string) (*url.URL, error) {
+	u, err := url.Parse(fmt.Sprintf("http://%s:%d/query?u=%s&p=%s&pretty=true",
+		sets["host"].(string),
+		sets["port"].(int),
+		sets["user"].(string),
+		sets["password"].(string),
+	))
+
+	if err != nil {
+		return nil, err
+	}
+
+	q := u.Query()
+	q.Set("q", query)
+	u.RawQuery = q.Encode()
+
+	return u, nil
+}
+
+// getURLResults returns result of GET to the specified url which has been parsed into a dtype.Results structure
+func getURLResults(url string) (dtype.Results, error) {
+	response, err := getHTTPResponse(url)
+	if err != nil {
+		return nil, err
+	}
+	results, err := parser.FromJSON(response)
+	if err != nil {
+		return nil, err
+	}
+	return results, nil
+}
+
+// getHTTPResponse returns HTTP response of GET to the specified url
+func getHTTPResponse(url string) ([]byte, error) {
+	response, err := http.Get(url)
+
+	if err != nil {
+		return nil, err
+	}
+	defer response.Body.Close()
+
+	return ioutil.ReadAll(response.Body)
+}

--- a/influxdb/parser/parser.go
+++ b/influxdb/parser/parser.go
@@ -1,0 +1,113 @@
+// +build linux
+
+/*
+http://www.apache.org/licenses/LICENSE-2.0.txt
+Copyright 2016 Intel Corporation
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package parser
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	"github.com/intelsdi-x/snap-plugin-collector-influxdb/influxdb/dtype"
+)
+
+// Parser holds data from unmarhalled json
+type Parser struct {
+	output dtype.Results
+}
+
+// To unmarshal JSON into a struct, structs have to contain exported fields
+type Response struct {
+	Results []ResultType `json:"results"`
+}
+
+type ResultType struct {
+	Series []SeriesType `json:"series"`
+}
+
+type SeriesType struct {
+	Name    string            `json:"name"`
+	Tags    map[string]string `json:"tags"`
+	Columns []string          `json:"columns"`
+	Values  [][]interface{}   `json:"values"`
+}
+
+// FromJSON unmarshals `data` and parses results to structure defined in dtype package (dtype.Results)
+func FromJSON(data []byte) (dtype.Results, error) {
+	p := &Parser{output: dtype.Results{}}
+	var response Response
+
+	err := json.Unmarshal(data, &response)
+
+	if err != nil {
+		return nil, err
+	}
+
+	for _, result := range response.Results {
+		for _, s := range result.Series {
+
+			if err := p.addSeries(s); err != nil {
+				return nil, err
+			}
+
+		}
+	}
+
+	return p.output, nil
+}
+
+// addSeries adds series defined by SeriesType structure to Parser `output` item
+func (p *Parser) addSeries(st SeriesType) error {
+	key := st.Name
+	data := map[string]interface{}{}
+
+	if id, ok := st.Tags["id"]; ok {
+		// if tag 'id' exist, add its value to series name (key)
+		key = key + "/" + id
+
+	} else if _, ok := st.Tags["path"]; ok {
+		// otherwise, treat the last path's element as an id
+		path := strings.Split(st.Tags["path"], "/")
+		key = key + "/" + path[len(path)-1]
+	}
+
+	if _, exist := p.output[key]; exist {
+		return fmt.Errorf("Series %+s is not unique", st.Name)
+	}
+
+	// validation content of values
+	if len(st.Values) < 1 {
+		return fmt.Errorf("Series %+s has no 'values' section", st.Name)
+	}
+
+	values := st.Values[0]
+
+	if len(values) != len(st.Columns) {
+		return fmt.Errorf("For series %+s can not assign %d values to %d columns", st.Name, len(values), len(st.Columns))
+	}
+
+	for i, column := range st.Columns {
+		data[column] = values[i]
+	}
+
+	// adding series to parser output
+	p.output[key] = &dtype.Series{
+		Data: data,
+		Tags: st.Tags,
+	}
+
+	return nil
+}

--- a/main.go
+++ b/main.go
@@ -1,0 +1,36 @@
+// +build linux
+
+/*
+http://www.apache.org/licenses/LICENSE-2.0.txt
+Copyright 2016 Intel Corporation
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"os"
+
+	// Import the snap plugin library
+	"github.com/intelsdi-x/snap/control/plugin"
+
+	// Import our collector plugin implementabtion
+	"github.com/intelsdi-x/snap-plugin-collector-influxdb/influxdb"
+)
+
+func main() {
+
+	plugin.Start(
+		plugin.NewPluginMeta(influxdb.Name, influxdb.Version, influxdb.Type, []string{}, []string{plugin.SnapGOBContentType}, plugin.ConcurrencyCount(1)),
+		influxdb.New(),
+		os.Args[1],
+	)
+}

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -1,0 +1,27 @@
+#!/bin/bash -e
+
+GITVERSION=`git describe --always`
+SOURCEDIR=$1
+BUILDDIR=$SOURCEDIR/build
+PLUGIN=`echo $SOURCEDIR | grep -oh "snap-.*"`
+ROOTFS=$BUILDDIR/rootfs
+BUILDCMD='go build -a -ldflags "-w"'
+
+echo
+echo "****  Snap Plugin Build  ****"
+echo
+
+# Disable CGO for builds
+export CGO_ENABLED=0
+
+# Clean build bin dir
+rm -rf $ROOTFS/*
+
+# Make dir
+mkdir -p $ROOTFS
+
+# Build plugin
+echo "Source Dir = $SOURCEDIR"
+echo "Building Snap Plugin: $PLUGIN"
+$BUILDCMD -o $ROOTFS/$PLUGIN
+

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -1,0 +1,85 @@
+#!/bin/bash -e
+# The script does automatic checking on a Go package and its sub-packages, including:
+# 1. gofmt         (http://golang.org/cmd/gofmt/)
+# 2. goimports     (https://github.com/bradfitz/goimports)
+# 3. golint        (https://github.com/golang/lint)
+# 4. go vet        (http://golang.org/cmd/vet)
+# 5. race detector (http://blog.golang.org/race-detector)
+# 6. test coverage (http://blog.golang.org/cover)
+
+# Capture what test we should run
+TEST_SUITE=$1
+
+if [[ $TEST_SUITE == "unit" ]]; then
+	go get github.com/axw/gocov/gocov
+	go get github.com/mattn/goveralls
+	go get -u github.com/golang/lint/golint
+	go get golang.org/x/tools/cmd/vet
+	go get golang.org/x/tools/cmd/goimports
+	go get github.com/smartystreets/goconvey/convey
+	go get github.com/stretchr/testify/mock
+	go get golang.org/x/tools/cmd/cover
+
+	COVERALLS_TOKEN=t47LG6BQsfLwb9WxB56hXUezvwpED6D11
+	TEST_DIRS="main.go influxdb/"
+	VET_DIRS=". ./influxdb/..."
+
+	set -e
+
+	# Automatic checks
+	echo "gofmt"
+	test -z "$(gofmt -l -d $TEST_DIRS | tee /dev/stderr)"
+
+	echo "goimports"
+	test -z "$(goimports -l -d $TEST_DIRS | tee /dev/stderr)"
+
+	# Useful but should not fail on link per: https://github.com/golang/lint
+	# "The suggestions made by golint are exactly that: suggestions. Golint is not perfect,
+	# and has both false positives and false negatives. Do not treat its output as a gold standard.
+	# We will not be adding pragmas or other knobs to suppress specific warnings, so do not expect
+	# or require code to be completely "lint-free". In short, this tool is not, and will never be,
+	# trustworthy enough for its suggestions to be enforced automatically, for example as part of
+	# a build process"
+	# echo "golint"
+	# golint ./...
+
+	echo "go vet"
+	go vet $VET_DIRS
+	# go test -race ./... - Lets disable for now
+
+	# Run test coverage on each subdirectories and merge the coverage profile.
+	echo "mode: count" > profile.cov
+
+	# Standard go tooling behavior is to ignore dirs with leading underscors
+	for dir in $(find . -maxdepth 10 -not -path './.git*' -not -path '*/_*' -not -path './examples/*' -not -path './scripts/*' -not -path './build/*' -not -path './Godeps/*' -type d);
+	do
+		if ls $dir/*.go &> /dev/null; then
+	    		go test --tags=unit -covermode=count -coverprofile=$dir/profile.tmp $dir
+	    		if [ -f $dir/profile.tmp ]
+	    		then
+	        		cat $dir/profile.tmp | tail -n +2 >> profile.cov
+	        		rm $dir/profile.tmp
+	    		fi
+		fi
+	done
+
+	go tool cover -func profile.cov
+
+	# Disabled Coveralls.io for now
+	# To submit the test coverage result to coveralls.io,
+	# use goveralls (https://github.com/mattn/goveralls)
+	# goveralls -coverprofile=profile.cov -service=travis-ci -repotoken t47LG6BQsfLwb9WxB56hXUezvwpED6D11
+	#
+	# If running inside Travis we update coveralls. We don't want his happening on Macs
+	# if [ "$TRAVIS" == "true" ]
+	# then
+	#     n=1
+	#     until [ $n -ge 6 ]
+	#     do
+	#         echo "posting to coveralls attempt $n of 5"
+	#         goveralls -v -coverprofile=profile.cov -service travis.ci -repotoken $COVERALLS_TOKEN && break
+	#         n=$[$n+1]
+	#         sleep 30
+	#     done
+	# fi
+fi


### PR DESCRIPTION
This plugin gather InfluxDB internal system monitoring information in response to commands `SHOW STATS` and `SHOW DIAGNOSTICS` which can be very useful to assist with troubleshooting and performance analysis of the database itself.
### Metrics

This plugin has the ability to gather:

a)  **diagnostic information** of InfluxDB system itself, represented by the metrics with prefix `/intel/influxdb/diagn/`

b)  **statistical information** of InfluxDB system itself, represented by the metrics with prefix `/intel/influxdb/stat/`
### Global config

For this plugin section "influxdb" in "collector" specifing the following options needs to be added:

| Name | Data Type | Description |
| --- | --- | --- |
| "host" | string | hostname of InfluxDB http API |
| "port" | int | port of InfluxDB http API (by default 8086) |
| "user" | string | user name |
| "password" | string | user password |

Example:

``` json
{
    "control": {
        "cache_ttl": "5s"
    },
    "scheduler": {
        "default_deadline": "5s",
        "worker_pool_size": 5
    },
    "plugins": {
        "collector": {
            "influxdb": {
                "all": {
                    "host": "localhost",
                    "port": 8086,
                    "user": "root",
                    "password": "influx"
                }
            }
        },
        "publisher": {},
        "processor": {}
    }
}
```
### Sample output (from "snapctl task watch"):

![image](https://cloud.githubusercontent.com/assets/11335874/13354422/37a785e6-dc9b-11e5-9b60-987dfcbee1d6.png)
